### PR TITLE
Fix PHP Run-time Error in Script

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -158,7 +158,7 @@ class FogBugz {
           "Login Error. " .
           "Please check the url, username and password. Error: " .
           $e->getMessage();
-      throw FogBugzLogonError($message, 0, $e);
+      throw new FogBugzLogonError($message, 0, $e);
     }
     return TRUE;
   }


### PR DESCRIPTION
Added a missing 'new' when FogBugzLoginError exception gets thrown in the logon() method.
