### PR TITLE
Fix CDATA issue

### DIFF
--- a/src/There4/FogBugz/Api.php
+++ b/src/There4/FogBugz/Api.php
@@ -191,7 +191,7 @@ class Api
     // make the request and throw an api exception if we detect an error
     try {
       $result = $this->curl->fetch($url);
-      $xml    = new \SimpleXMLElement($result);
+      $xml    = new \SimpleXMLElement($result, LIBXML_NOCDATA);
       if (isset($xml->error)) {
         $code    = (string) $xml->error['code'];
         $message = (string) $xml->error;


### PR DESCRIPTION
Hi there,

I was running '$fogbugz->listProjects()' and not getting any 
project names. Turns out this was because the names were inside 
<![CDATA[ ]>. 

This fixes it by using the LIBXML_NOCDATA option for SimpleXMLElement.

Cheers,
James
